### PR TITLE
Added R2_pred and R2_lik for glmmTMB classes

### DIFF
--- a/R/r2_lik.R
+++ b/R/r2_lik.R
@@ -245,7 +245,7 @@ R2_lik <- function(mod = NULL, mod.r = NULL) {
         if (family(mod)[[1]] != family(mod.r)[[1]]) {
             stop("Sorry, but mod and mod.r must be from the same family of distributions.")
         }
-        return(R2_lik.glmmTMB(mod, mod.r)[1])
+        return(R2_lik.glmmTMB(mod, mod.r))
     }
     
     if (class(mod)[1] == "phylolm") {

--- a/R/r2_lik.R
+++ b/R/r2_lik.R
@@ -234,7 +234,7 @@ R2_lik <- function(mod = NULL, mod.r = NULL) {
         return(R2_lik.glmerMod(mod, mod.r)[1])
     }
     
-    if (class(mod)[1] == "glmerTMB") {
+    if (class(mod)[1] == "glmmTMB") {
         if (!is.object(mod.r)) {
             y <- model.frame(mod)[, 1]
             mod.r <- glm(y ~ 1, family = family(mod)[[1]])
@@ -245,7 +245,7 @@ R2_lik <- function(mod = NULL, mod.r = NULL) {
         if (family(mod)[[1]] != family(mod.r)[[1]]) {
             stop("Sorry, but mod and mod.r must be from the same family of distributions.")
         }
-        return(R2_lik.glmmTMB(mod, mod.r))
+      return(R2_lik.glmmTMB(mod, mod.r))
     }
     
     if (class(mod)[1] == "phylolm") {

--- a/R/r2_lik.R
+++ b/R/r2_lik.R
@@ -341,7 +341,7 @@ R2_lik.glmerMod <- function(mod = NULL, mod.r = NULL) {
 R2_lik.glmmTMB <- function(mod = NULL, mod.r = NULL) {
     X <- model.matrix(mod)
     n <- dim(X)[1]
-    R2_lik <- (1 - exp(-2/n * (logLik(mod) - logLik(mod.r))))/(1 - exp(2/n * logLik(mod.r)))
+    R2_lik <- (1 - exp(-2/n * as.numeric(logLik(mod) - logLik(mod.r))))/(1 - exp(2/n * as.numeric(logLik(mod.r))))
     return(R2_lik)
 }
 

--- a/R/r2_pred.R
+++ b/R/r2_pred.R
@@ -285,6 +285,20 @@ R2_pred <- function(mod = NULL, mod.r = NULL, gaussian.pred = "tip_rm", phy = NU
         return(R2_pred.glmerMod(mod, mod.r)[1])
     }
     
+    if (class(mod)[1] == "glmmTMB") {
+        if (!is.object(mod.r)) {
+            y <- model.frame(mod)[, 1]
+            mod.r <- glm(y ~ 1, family = family(mod)[[1]])
+        }
+        if (!is.element(class(mod.r)[1], c("glmmTMB", "glm"))) {
+            stop("mod.r must be class glmmTMB or glm.")
+        }
+        if (family(mod)[[1]] != family(mod.r)[[1]]) {
+            stop("Sorry, but mod and mod.r must be from the same family of distributions.")
+        }
+        return(R2_pred.glmmTMB(mod, mod.r)[1])
+    }
+
     if (class(mod)[1] == "phylolm") {
         if (!is.object(mod.r)) {
             y <- mod$y
@@ -388,6 +402,15 @@ R2_pred.lmerMod <- function(mod = NA, mod.r = NA) {
 }
 
 R2_pred.glmerMod <- function(mod = NA, mod.r = NA) {
+  y <- model.frame(mod)[, 1]
+  if(is.matrix(y)) y <- y[,1]/rowSums(y)
+  SSE.pred <- var(y - fitted(mod))
+  SSE.pred.r <- var(y - stats::fitted(mod.r))
+  R2_pred <- 1 - SSE.pred/SSE.pred.r
+  return(R2_pred)
+}
+
+R2_pred.glmmTMB <- function(mod = NA, mod.r = NA) {
   y <- model.frame(mod)[, 1]
   if(is.matrix(y)) y <- y[,1]/rowSums(y)
   SSE.pred <- var(y - fitted(mod))

--- a/R/r2_pred.R
+++ b/R/r2_pred.R
@@ -2,15 +2,15 @@
 #'
 #' Calculate partial and total R2s for LMM, GLMM, PGLS, and PGLMM using R2_pred, an R2 based on the variance of the difference between the observed and predicted values of a fitted model.
 #' 
-#' @param mod A regression model with one of the following classes: 'lm', 'glm', 'lmerMod', 'glmerMod', 'phylolm', 'gls', 'pglmm', pglmm_compare', 'binaryPGLMM', or 'communityPGLMM'.
+#' @param mod A regression model with one of the following classes: 'lm', 'glm', 'lmerMod', 'glmerMod', 'glmmTMB', 'phylolm', 'gls', 'pglmm', pglmm_compare', 'binaryPGLMM', or 'communityPGLMM'.
 #' @param mod.r A reduced model; if not provided, the total R2 will be given by setting 'mod.r' to the model corresponding to 'mod' with the intercept as the only predictor.
 #' @param phy The phylogeny for phylogenetic models (as a 'phylo' object), which must be specified for models of class `phylolm`.
 #' @param gaussian.pred For models of classes `pglmm` and `pglmm_compare` when family = gaussian, which type of prediction to calculate.
 #' @export
 #'
-#' @details  R2_pred works with classes 'lm', 'glm', 'lmerMod', 'glmerMod', 'phylolm', 'phyloglm', 'gls', 'pglmm', 'pglmm_compare', binaryPGLMM', and 'communityPGLMM' (family = gaussian and binomial).
+#' @details  R2_pred works with classes 'lm', 'glm', 'lmerMod', 'glmerMod', 'glmmTMB', 'phylolm', 'phyloglm', 'gls', 'pglmm', 'pglmm_compare', binaryPGLMM', and 'communityPGLMM' (family = gaussian and binomial).
 #' 
-#' \strong{LMM (lmerMod), GLMM (glmerMod), PGLMM (pglmm, pglmm_compare, binaryPGLMM and communityPGLMM):}
+#' \strong{LMM (lmerMod), GLMM (glmerMod, glmmTMB), PGLMM (pglmm, pglmm_compare, binaryPGLMM and communityPGLMM):}
 #' 
 #' \deqn{partial R2 = 1 - var(y - y.fitted.f)/var(y - y.fitted.r)}
 #' 
@@ -227,10 +227,10 @@ R2_pred <- function(mod = NULL, mod.r = NULL, gaussian.pred = "tip_rm", phy = NU
     if (class(mod)[1] == "merModLmerTest") 
         class(mod) <- "lmerMod"
     
-    if (!is.element(class(mod)[1], c("lm", "glm", "lmerMod", "glmerMod", "phylolm", 
+    if (!is.element(class(mod)[1], c("lm", "glm", "lmerMod", "glmerMod", "glmmTMB", "phylolm", 
                                      "gls", "pglmm", "pglmm_compare", "binaryPGLMM",
                                      "communityPGLMM"))) {
-        stop("mod must be class one of classes lm, glm, lmerMod, glmerMod, phylolm (but not phyloglm), gls, pglmm, pglmm_compare, binaryPGLMM, communityPGLMM.")
+        stop("mod must be class one of classes lm, glm, lmerMod, glmerMod, glmmTMB, phylolm (but not phyloglm), gls, pglmm, pglmm_compare, binaryPGLMM, communityPGLMM.")
     }
     
     if (class(mod)[1] == "lm") {

--- a/R/r2_resid.R
+++ b/R/r2_resid.R
@@ -3,12 +3,12 @@
 #' Calculate partial and total R2s for LMM, GLMM, PGLS, and PGLMM using R2_resid, an extension of ordinary least-squares (OLS) R2s. For LMMs and GLMMs, R2_resid is related to the method proposed by Nakagawa and Schielzeth (2013).
 #' 
 
-#' @param mod A regression model with one of the following classes: 'lm', 'glm', 'lmerMod', 'glmerMod', 'phylolm', 'gls', 'pglmm_compare' or 'binaryPGLMM'. For 'glmerMod', only family = c('binomial', 'poisson') are supported.
+#' @param mod A regression model with one of the following classes: 'lm', 'glm', 'lmerMod', 'glmerMod', 'glmmTMB', 'phylolm', 'gls', 'pglmm_compare' or 'binaryPGLMM'. For 'glmerMod', only family = c('binomial', 'poisson') are supported.
 #' @param mod.r A reduced model; if not provided, the total R2 will be given by setting 'mod.r' to the model corresponding to 'mod' with the intercept as the only predictor.
 #' @param sigma2_d Distribution-specific variance \eqn{\sigma^2_d}{sigma2d} (see Details). For binomial GLMs, GLMMs and PGLMMs with logit link functions, options are c('s2w', 'NS', 'rNS'). For binomial GLMs, GLMMs and PGLMMs with probit link functions, options are c('s2w', 'NS'). Other families use 's2w'.
 #' @param phy The phylogeny for phylogenetic models (as a 'phylo' object), which must be specified for models of class `phylolm`.
 #' 
-#' @details  R2_resid works with classes 'lm', 'glm', 'lmerMod', 'glmerMod', 'phylolm', 'pglmm_compare', and 'binaryPGLMM'.
+#' @details  R2_resid works with classes 'lm', 'glm', 'lmerMod', 'glmerMod', 'glmmTMB', 'phylolm', 'pglmm_compare', and 'binaryPGLMM'.
 #' 
 #' \strong{LMM (lmerMod):}
 #' 
@@ -220,8 +220,8 @@ R2_resid <- function(mod = NULL, mod.r = NULL, sigma2_d = c("s2w", "NS", "rNS"),
     if (class(mod)[1] == "merModLmerTest") 
         class(mod) <- "lmerMod"
     
-    if (!is.element(class(mod)[1], c("lm", "glm", "lmerMod", "glmerMod", "phylolm", "gls", "pglmm_compare", "binaryPGLMM"))) {
-        stop("mod must be class one of classes lm, glm, lmerMod, glmerMod, phylolm, gls, pglmm_compare, binaryPGLMM.")
+    if (!is.element(class(mod)[1], c("lm", "glm", "lmerMod", "glmerMod", "glmmTMB", "phylolm", "gls", "pglmm_compare", "binaryPGLMM"))) {
+        stop("mod must be class one of classes lm, glm, lmerMod, glmerMod, glmmTMB, phylolm, gls, pglmm_compare, binaryPGLMM.")
     }
     
     sigma2_d <- match.arg(sigma2_d)

--- a/R/r2_resid.R
+++ b/R/r2_resid.R
@@ -3,12 +3,12 @@
 #' Calculate partial and total R2s for LMM, GLMM, PGLS, and PGLMM using R2_resid, an extension of ordinary least-squares (OLS) R2s. For LMMs and GLMMs, R2_resid is related to the method proposed by Nakagawa and Schielzeth (2013).
 #' 
 
-#' @param mod A regression model with one of the following classes: 'lm', 'glm', 'lmerMod', 'glmerMod', 'glmmTMB', 'phylolm', 'gls', 'pglmm_compare' or 'binaryPGLMM'. For 'glmerMod', only family = c('binomial', 'poisson') are supported.
+#' @param mod A regression model with one of the following classes: 'lm', 'glm', 'lmerMod', 'glmerMod', 'phylolm', 'gls', 'glmm_compare' or 'binaryPGLMM'. For 'glmerMod', only family = c('binomial', 'poisson') are supported.
 #' @param mod.r A reduced model; if not provided, the total R2 will be given by setting 'mod.r' to the model corresponding to 'mod' with the intercept as the only predictor.
 #' @param sigma2_d Distribution-specific variance \eqn{\sigma^2_d}{sigma2d} (see Details). For binomial GLMs, GLMMs and PGLMMs with logit link functions, options are c('s2w', 'NS', 'rNS'). For binomial GLMs, GLMMs and PGLMMs with probit link functions, options are c('s2w', 'NS'). Other families use 's2w'.
 #' @param phy The phylogeny for phylogenetic models (as a 'phylo' object), which must be specified for models of class `phylolm`.
 #' 
-#' @details  R2_resid works with classes 'lm', 'glm', 'lmerMod', 'glmerMod', 'glmmTMB', 'phylolm', 'pglmm_compare', and 'binaryPGLMM'.
+#' @details  R2_resid works with classes 'lm', 'glm', 'lmerMod', 'glmerMod', 'phylolm', 'pglmm_compare', and 'binaryPGLMM'.
 #' 
 #' \strong{LMM (lmerMod):}
 #' 
@@ -220,8 +220,8 @@ R2_resid <- function(mod = NULL, mod.r = NULL, sigma2_d = c("s2w", "NS", "rNS"),
     if (class(mod)[1] == "merModLmerTest") 
         class(mod) <- "lmerMod"
     
-    if (!is.element(class(mod)[1], c("lm", "glm", "lmerMod", "glmerMod", "glmmTMB", "phylolm", "gls", "pglmm_compare", "binaryPGLMM"))) {
-        stop("mod must be class one of classes lm, glm, lmerMod, glmerMod, glmmTMB, phylolm, gls, pglmm_compare, binaryPGLMM.")
+    if (!is.element(class(mod)[1], c("lm", "glm", "lmerMod", "glmerMod", "phylolm", "gls", "pglmm_compare", "binaryPGLMM"))) {
+        stop("mod must be class one of classes lm, glm, lmerMod, glmerMod, phylolm, gls, pglmm_compare, binaryPGLMM.")
     }
     
     sigma2_d <- match.arg(sigma2_d)

--- a/R/r2_resid.R
+++ b/R/r2_resid.R
@@ -3,7 +3,7 @@
 #' Calculate partial and total R2s for LMM, GLMM, PGLS, and PGLMM using R2_resid, an extension of ordinary least-squares (OLS) R2s. For LMMs and GLMMs, R2_resid is related to the method proposed by Nakagawa and Schielzeth (2013).
 #' 
 
-#' @param mod A regression model with one of the following classes: 'lm', 'glm', 'lmerMod', 'glmerMod', 'phylolm', 'gls', 'glmm_compare' or 'binaryPGLMM'. For 'glmerMod', only family = c('binomial', 'poisson') are supported.
+#' @param mod A regression model with one of the following classes: 'lm', 'glm', 'lmerMod', 'glmerMod', 'phylolm', 'gls', 'pglmm_compare' or 'binaryPGLMM'. For 'glmerMod', only family = c('binomial', 'poisson') are supported.
 #' @param mod.r A reduced model; if not provided, the total R2 will be given by setting 'mod.r' to the model corresponding to 'mod' with the intercept as the only predictor.
 #' @param sigma2_d Distribution-specific variance \eqn{\sigma^2_d}{sigma2d} (see Details). For binomial GLMs, GLMMs and PGLMMs with logit link functions, options are c('s2w', 'NS', 'rNS'). For binomial GLMs, GLMMs and PGLMMs with probit link functions, options are c('s2w', 'NS'). Other families use 's2w'.
 #' @param phy The phylogeny for phylogenetic models (as a 'phylo' object), which must be specified for models of class `phylolm`.


### PR DESCRIPTION
These functions are straightforward and rely only on the logLik, fitted, model.frame and model.matrix functions defined for glmmTMB. I feel like the R2_resid could also be implemented for these classes, but since I am not 100% sure I did not implement the corresponding methods. The glmmTMB package needs to be loaded for the functions to work, otherwise, the default methods will be used and lead to an error (e.g. model frame has the wrong dimension).

Hope this may prove useful...

Julien.